### PR TITLE
Add Spyke Turizm web UI, server and SQLite backend with login API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+spyke.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # Vfsbot
+
+## Spyke Turizm giriş ekranını veritabanı ile çalıştırma (macOS)
+
+1. Terminal açın ve proje klasörüne girin:
+
+```bash
+cd /workspace/Vfsbot
+```
+
+2. Sunucuyu başlatın:
+
+```bash
+python3 server.py
+```
+
+3. Tarayıcıdan açın:
+
+```text
+http://localhost:4173
+```
+
+> Durdurmak için terminalde `Ctrl + C`.
+
+## Varsayılan giriş bilgisi
+
+- Kullanıcı adı: `Furkan Kutas`
+- Şifre: `Furkan13!`
+
+## Veritabanı bilgisi
+
+- Uygulama açıldığında otomatik `spyke.db` SQLite veritabanı oluşturulur.
+- `users` tablosu giriş kullanıcılarını tutar.
+- `passport_images` tablosu ileride pasaport görsellerini saklamak için hazırdır.
+
+## Logo kullanımı
+
+- Sol panelde şu anda bir logo yer tutucu var.
+- Logo dosyanızı projeye ekleyip `index.html` içinde `logo-placeholder` bölümünü `<img>` ile değiştirebilirsiniz.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="tr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spyke Turizm | Giriş</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main id="loginScreen" class="login-layout">
+      <section class="brand-panel">
+        <div class="logo-wrap" aria-label="Spyke Turizm logosu alanı">
+          <div class="logo-placeholder">
+            <span>SPYKETURIZM</span>
+            <small>Logo dosyanı buraya ekleyebilirsin</small>
+          </div>
+        </div>
+        <p class="brand-description">
+          Vize danışmanlığı, pasaport evrak kontrolü ve başvuru süreci takibini hızlı ve net şekilde sunuyoruz.
+        </p>
+      </section>
+
+      <section class="form-panel" aria-label="Giriş formu">
+        <h2>Hoş geldiniz</h2>
+        <p>Hesabınıza kullanıcı adı ve şifrenizle giriş yapın.</p>
+
+        <form id="loginForm">
+          <label for="username">Kullanıcı Adı</label>
+          <input id="username" name="username" type="text" placeholder="kullanici.adi" required />
+
+          <label for="password">Şifre</label>
+          <input id="password" name="password" type="password" placeholder="••••••••" required />
+
+          <div class="form-row">
+            <label class="checkbox">
+              <input type="checkbox" name="remember" />
+              Beni hatırla
+            </label>
+            <a href="#">Şifremi unuttum</a>
+          </div>
+
+          <button type="submit">Giriş Yap</button>
+          <p id="message" class="message" aria-live="polite"></p>
+          <p class="helper">Test hesabı: Furkan Kutas / Furkan13!</p>
+        </form>
+      </section>
+    </main>
+
+    <main id="dashboardScreen" class="dashboard hidden" aria-label="Ana sayfa">
+      <aside class="sidebar">
+        <h2>Spyke Turizm</h2>
+        <nav>
+          <button class="menu-item active" data-view="home">Ana Sayfa</button>
+          <button class="menu-item" data-view="customers">Müşteriler</button>
+          <button class="menu-item" data-view="appointment">Randevu Al</button>
+          <button class="menu-item" data-view="accounting">Muhasebe</button>
+          <button class="menu-item" data-view="passport">Pasaport Takip</button>
+          <button id="logoutBtn" class="menu-item logout">Çıkış</button>
+        </nav>
+      </aside>
+
+      <section class="dashboard-content">
+        <article class="panel" data-panel="home">
+          <h1>Ana Sayfa</h1>
+          <p>Spyke Turizm yönetim ekranına hoş geldiniz.</p>
+        </article>
+
+        <article class="panel hidden" data-panel="customers">
+          <h1>Müşteriler</h1>
+          <p>Müşteri listesi ve iletişim bilgileri bu alanda görüntülenecek.</p>
+        </article>
+
+        <article class="panel hidden" data-panel="appointment">
+          <h1>Randevu Al</h1>
+          <p>Yeni randevu planlama ve takvim işlemleri burada olacak.</p>
+        </article>
+
+        <article class="panel hidden" data-panel="accounting">
+          <h1>Muhasebe</h1>
+          <p>Ödeme, fatura ve finans takip modülü bu alanda yer alacak.</p>
+        </article>
+
+        <article class="panel hidden" data-panel="passport">
+          <h1>Pasaport Takip</h1>
+          <p>Pasaport görsel yükleme ve başvuru süreç takibi burada yönetilecek.</p>
+        </article>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,66 @@
+const loginForm = document.getElementById('loginForm');
+const messageEl = document.getElementById('message');
+const loginScreen = document.getElementById('loginScreen');
+const dashboardScreen = document.getElementById('dashboardScreen');
+const menuItems = document.querySelectorAll('.menu-item[data-view]');
+const panels = document.querySelectorAll('.panel');
+const logoutBtn = document.getElementById('logoutBtn');
+
+const showPanel = (panelName) => {
+  panels.forEach((panel) => {
+    panel.classList.toggle('hidden', panel.dataset.panel !== panelName);
+  });
+
+  menuItems.forEach((item) => {
+    item.classList.toggle('active', item.dataset.view === panelName);
+  });
+};
+
+menuItems.forEach((item) => {
+  item.addEventListener('click', () => {
+    showPanel(item.dataset.view);
+  });
+});
+
+logoutBtn.addEventListener('click', () => {
+  dashboardScreen.classList.add('hidden');
+  loginScreen.classList.remove('hidden');
+  loginForm.reset();
+  messageEl.textContent = '';
+  messageEl.className = 'message';
+  showPanel('home');
+});
+
+loginForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+
+  const formData = new FormData(loginForm);
+  const username = formData.get('username')?.toString().trim();
+  const password = formData.get('password')?.toString();
+
+  messageEl.textContent = 'Giriş kontrol ediliyor...';
+  messageEl.className = 'message';
+
+  try {
+    const response = await fetch('/api/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ username, password })
+    });
+
+    const result = await response.json();
+    messageEl.textContent = result.message;
+    messageEl.className = response.ok ? 'message success' : 'message error';
+
+    if (response.ok) {
+      loginScreen.classList.add('hidden');
+      dashboardScreen.classList.remove('hidden');
+      showPanel('home');
+    }
+  } catch (_error) {
+    messageEl.textContent = 'Sunucuya bağlanılamadı. Lütfen tekrar deneyin.';
+    messageEl.className = 'message error';
+  }
+});

--- a/server.py
+++ b/server.py
@@ -1,0 +1,113 @@
+import base64
+import hashlib
+import hmac
+import json
+import os
+import sqlite3
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+DB_PATH = os.path.join(ROOT, "spyke.db")
+PORT = 4173
+
+
+def hash_password(password: str, salt: bytes | None = None) -> str:
+  if salt is None:
+    salt = os.urandom(16)
+  digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 120000)
+  return f"{base64.b64encode(salt).decode()}${base64.b64encode(digest).decode()}"
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+  salt_b64, expected_b64 = password_hash.split("$", 1)
+  salt = base64.b64decode(salt_b64.encode())
+  expected = base64.b64decode(expected_b64.encode())
+  candidate = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 120000)
+  return hmac.compare_digest(candidate, expected)
+
+
+def setup_database() -> None:
+  with sqlite3.connect(DB_PATH) as conn:
+    conn.execute(
+      """
+      CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT UNIQUE NOT NULL,
+        password_hash TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+      """
+    )
+    conn.execute(
+      """
+      CREATE TABLE IF NOT EXISTS passport_images (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        file_name TEXT NOT NULL,
+        file_path TEXT NOT NULL,
+        uploaded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES users(id)
+      )
+      """
+    )
+    user = conn.execute("SELECT id FROM users WHERE username = ?", ("Furkan Kutas",)).fetchone()
+    if user is None:
+      conn.execute(
+        "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+        ("Furkan Kutas", hash_password("Furkan13!")),
+      )
+
+
+class AppHandler(SimpleHTTPRequestHandler):
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, directory=ROOT, **kwargs)
+
+  def _json_response(self, status: int, payload: dict) -> None:
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    self.send_response(status)
+    self.send_header("Content-Type", "application/json; charset=utf-8")
+    self.send_header("Content-Length", str(len(body)))
+    self.end_headers()
+    self.wfile.write(body)
+
+  def do_POST(self):  # noqa: N802
+    if self.path != "/api/login":
+      return self._json_response(404, {"ok": False, "message": "Bulunamadı"})
+
+    try:
+      content_length = int(self.headers.get("Content-Length", "0"))
+      raw_body = self.rfile.read(content_length)
+      data = json.loads(raw_body.decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+      return self._json_response(400, {"ok": False, "message": "Geçersiz istek."})
+
+    username = (data.get("username") or "").strip()
+    password = data.get("password") or ""
+    if not username or not password:
+      return self._json_response(400, {"ok": False, "message": "Kullanıcı adı ve şifre zorunludur."})
+
+    with sqlite3.connect(DB_PATH) as conn:
+      row = conn.execute(
+        "SELECT username, password_hash FROM users WHERE username = ?", (username,)
+      ).fetchone()
+
+    if row is None:
+      return self._json_response(401, {"ok": False, "message": "Kullanıcı adı veya şifre hatalı."})
+
+    db_username, password_hash = row
+    if not verify_password(password, password_hash):
+      return self._json_response(401, {"ok": False, "message": "Kullanıcı adı veya şifre hatalı."})
+
+    return self._json_response(200, {"ok": True, "message": f"Hoş geldin {db_username}"})
+
+  def do_GET(self):  # noqa: N802
+    if self.path == "/api/health":
+      return self._json_response(200, {"ok": True, "db": DB_PATH})
+    return super().do_GET()
+
+
+if __name__ == "__main__":
+  setup_database()
+  server = ThreadingHTTPServer(("0.0.0.0", PORT), AppHandler)
+  print(f"Spyke Turizm app running at http://localhost:{PORT}")
+  server.serve_forever()

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,263 @@
+:root {
+  --green-50: #f0fff4;
+  --green-100: #dcfce7;
+  --green-300: #86efac;
+  --green-500: #22c55e;
+  --green-700: #15803d;
+  --text-main: #1f2937;
+  --text-muted: #6b7280;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: var(--text-main);
+  background: linear-gradient(145deg, #f7fff8 0%, #e9ffe9 45%, #ddfce4 100%);
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.login-layout {
+  width: min(960px, 100%);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  background: #fff;
+  border-radius: 24px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(20, 83, 45, 0.15);
+}
+
+.brand-panel {
+  background: linear-gradient(170deg, var(--green-500) 0%, var(--green-700) 100%);
+  color: #fff;
+  padding: 3rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.logo-wrap {
+  width: 100%;
+}
+
+.logo-placeholder {
+  border: 2px dashed rgba(255, 255, 255, 0.6);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  background: rgba(8, 23, 16, 0.18);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.logo-placeholder span {
+  font-size: 1.9rem;
+  letter-spacing: 0.08em;
+  font-weight: 800;
+}
+
+.logo-placeholder small {
+  color: #ddffe7;
+  font-size: 0.9rem;
+}
+
+.brand-description {
+  margin: 0;
+  line-height: 1.7;
+  color: #ebffef;
+}
+
+.form-panel {
+  padding: 3rem;
+}
+
+.form-panel h2 {
+  margin: 0;
+  font-size: 1.7rem;
+}
+
+.form-panel > p {
+  margin: 0.7rem 0 2rem;
+  color: var(--text-muted);
+}
+
+form {
+  display: grid;
+  gap: 0.85rem;
+}
+
+label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+input[type="text"],
+input[type="password"] {
+  border: 1px solid #d1d5db;
+  border-radius: 0.8rem;
+  padding: 0.9rem 1rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus {
+  border-color: var(--green-500);
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.15);
+}
+
+.form-row {
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.checkbox {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-weight: 500;
+}
+
+.form-row a {
+  color: var(--green-700);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+button {
+  margin-top: 0.8rem;
+  border: none;
+  border-radius: 0.8rem;
+  padding: 0.95rem 1rem;
+  background: var(--green-500);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, background-color 0.2s ease;
+}
+
+button:hover {
+  background: #16a34a;
+  transform: translateY(-1px);
+}
+
+.message {
+  min-height: 1.5rem;
+  margin: 0.25rem 0 0;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.message.success {
+  color: #166534;
+}
+
+.message.error {
+  color: #b91c1c;
+}
+
+.helper {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.dashboard {
+  width: min(1120px, 100%);
+  min-height: 700px;
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  background: #fff;
+  border-radius: 24px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(20, 83, 45, 0.15);
+}
+
+.sidebar {
+  background: linear-gradient(170deg, var(--green-700) 0%, #0f5a2e 100%);
+  color: #fff;
+  padding: 2rem 1.25rem;
+}
+
+.sidebar h2 {
+  margin-top: 0;
+  margin-bottom: 1.2rem;
+}
+
+.sidebar nav {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.menu-item {
+  width: 100%;
+  text-align: left;
+  margin: 0;
+  padding: 0.8rem 1rem;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 0.7rem;
+}
+
+.menu-item.active {
+  background: #fff;
+  color: var(--green-700);
+}
+
+.menu-item.logout {
+  background: rgba(248, 113, 113, 0.22);
+}
+
+.menu-item.logout:hover {
+  background: rgba(248, 113, 113, 0.35);
+}
+
+.dashboard-content {
+  padding: 2rem;
+  background: #f8fffa;
+}
+
+.panel {
+  background: #fff;
+  border: 1px solid #d1fae5;
+  border-radius: 1rem;
+  padding: 1.5rem;
+}
+
+.panel h1 {
+  margin-top: 0;
+}
+
+@media (max-width: 860px) {
+  body {
+    padding: 1rem;
+  }
+
+  .login-layout,
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-panel,
+  .form-panel,
+  .dashboard-content {
+    padding: 1.2rem;
+  }
+
+  .logo-placeholder span {
+    font-size: 1.5rem;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a minimal local web app for Spyke Turizm including a login screen, basic dashboard and a small API to authenticate users.
- Persist user accounts and passport image metadata in a local SQLite database for development and testing.
- Offer a simple developer experience to run the app locally on macOS via `python3 server.py`.

### Description

- Added a static frontend with `index.html`, `styles.css`, and `script.js` implementing a login screen and a basic dashboard UI with client-side navigation and a fetch-based POST to `/api/login`.
- Implemented `server.py` which serves static files, exposes `/api/login` (password verification) and `/api/health`, initializes `spyke.db` with `users` and `passport_images` tables, and seeds a default user (`Furkan Kutas`).
- Added secure password hashing and verification using PBKDF2 with `hashlib` and `hmac` via `hash_password` and `verify_password` helpers.
- Added usage documentation to `README.md` and ignored the generated database file via `.gitignore` (`spyke.db`).

### Testing

- No automated tests were included or executed as part of this change.
- Basic local smoke checks were exercised by starting the server and exercising the login flow (manual verification only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b676d0b27c8324a280c33b0ce386d4)